### PR TITLE
Find rustup if it isn't in `$CARGO_HOME/bin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.cargo


### PR DESCRIPTION
Some users may not have `$CARGO_HOME/bin/rustup`, so look for it on the `$PATH` if this is the case.

/cc #2 